### PR TITLE
Add sleep statement

### DIFF
--- a/citizenshell/serialshell.py
+++ b/citizenshell/serialshell.py
@@ -38,6 +38,7 @@ class SerialShell(AbstractRemoteShell):
                 self._read_until("Password: ")
                 self._write(self._password + "\n")
 
+        sleep(.1)
         self._write("export PS1='%s'\n" % self._prompt)
         self._read_until(self._prompt)
         self._read_until(self._prompt)


### PR DESCRIPTION
Fixes an issue where the login fails on TTL-232R-3V3. My guess is that some buffer is not flushed. The 0.1 seconds fix that.